### PR TITLE
fix(medecho): UNIC-1014 Set schedule 1 hour later

### DIFF
--- a/dags/config/ingestion/medecho_config.json
+++ b/dags/config/ingestion/medecho_config.json
@@ -1,6 +1,6 @@
 {
   "concurrency": 3,
-  "schedule": "0 7 * * 7",
+  "schedule": "0 8 * * 7",
   "timeout_hours": 4,
   "steps": [{
     "namespace": "ingestion",


### PR DESCRIPTION
Some tables are partially loaded, because upload is not finished yet on integration-db.