### PR TITLE
feat: UNIC-1118 Add new stat-urgence tables

### DIFF
--- a/dags/config/ingestion/staturgence_config.json
+++ b/dags/config/ingestion/staturgence_config.json
@@ -5,16 +5,19 @@
   "steps": [{
     "namespace": "raw",
     "main_class": "bio.ferlab.ui.etl.red.raw.Main",
-    "publish_class": "bio.ferlab.ui.etl.red.raw.UpdateLog",
+    "publish_class": "",
     "schemas": ["staturgence"],
     "datasets":
     [
+      {"dataset_id":"raw_staturgence_recherche_activity"      , "cluster_type": "small" , "run_type": "default", "cluster_specs": {}, "dependencies": []},
+      {"dataset_id":"raw_staturgence_recherche_drug"          , "cluster_type": "small" , "run_type": "default", "cluster_specs": {}, "dependencies": []},
+      {"dataset_id":"raw_staturgence_recherche_episode*"      , "cluster_type": "medium", "run_type": "default", "cluster_specs": {}, "dependencies": []},
+      {"dataset_id":"raw_staturgence_recherche_generic"       , "cluster_type": "small" , "run_type": "default", "cluster_specs": {}, "dependencies": []},
+      {"dataset_id":"raw_staturgence_recherche_location*"     , "cluster_type": "small" , "run_type": "default", "cluster_specs": {}, "dependencies": []},
       {"dataset_id":"raw_staturgence_recherche_logtransaction", "cluster_type": "small" , "run_type": "default", "cluster_specs": {}, "dependencies": []},
-      {"dataset_id":"raw_staturgence_recherche_bcm"           , "cluster_type": "small" , "run_type": "default", "cluster_specs": {}, "dependencies": []},
-      {"dataset_id":"raw_staturgence_recherche_episode"       , "cluster_type": "small" , "run_type": "default", "cluster_specs": {}, "dependencies": []},
-      {"dataset_id":"raw_staturgence_recherche_fadm"          , "cluster_type": "small" , "run_type": "default", "cluster_specs": {}, "dependencies": []},
-      {"dataset_id":"raw_staturgence_recherche_priseencharge" , "cluster_type": "small" , "run_type": "default", "cluster_specs": {}, "dependencies": []},
-      {"dataset_id":"raw_staturgence_recherche_triage"        , "cluster_type": "small" , "run_type": "default", "cluster_specs": {}, "dependencies": []}
+      {"dataset_id":"raw_staturgence_recherche_patient*"      , "cluster_type": "small" , "run_type": "default", "cluster_specs": {}, "dependencies": []},
+      {"dataset_id":"raw_staturgence_recherche_pilotage"      , "cluster_type": "small" , "run_type": "default", "cluster_specs": {}, "dependencies": []},
+      {"dataset_id":"raw_staturgence_recherche_test"          , "cluster_type": "small" , "run_type": "default", "cluster_specs": {}, "dependencies": []}
     ]
   }, {
     "namespace": "anonymized",
@@ -23,12 +26,15 @@
     "schemas": [],
     "datasets":
     [
-      {"dataset_id":"anonymized_staturgence_recherche_logtransaction", "cluster_type": "small" , "run_type": "initial", "cluster_specs": {}, "dependencies": []},
-      {"dataset_id":"anonymized_staturgence_recherche_bcm"           , "cluster_type": "small" , "run_type": "initial", "cluster_specs": {}, "dependencies": []},
-      {"dataset_id":"anonymized_staturgence_recherche_episode"       , "cluster_type": "small" , "run_type": "initial", "cluster_specs": {}, "dependencies": []},
-      {"dataset_id":"anonymized_staturgence_recherche_fadm"          , "cluster_type": "small" , "run_type": "initial", "cluster_specs": {}, "dependencies": []},
-      {"dataset_id":"anonymized_staturgence_recherche_priseencharge" , "cluster_type": "small" , "run_type": "initial", "cluster_specs": {}, "dependencies": []},
-      {"dataset_id":"anonymized_staturgence_recherche_triage"        , "cluster_type": "small" , "run_type": "initial", "cluster_specs": {}, "dependencies": []}
+      {"dataset_id":"raw_staturgence_recherche_activity"      , "cluster_type": "small" , "run_type": "initial", "cluster_specs": {}, "dependencies": []},
+      {"dataset_id":"raw_staturgence_recherche_drug"          , "cluster_type": "small" , "run_type": "initial", "cluster_specs": {}, "dependencies": []},
+      {"dataset_id":"raw_staturgence_recherche_episode*"      , "cluster_type": "medium", "run_type": "initial", "cluster_specs": {}, "dependencies": []},
+      {"dataset_id":"raw_staturgence_recherche_generic"       , "cluster_type": "small" , "run_type": "initial", "cluster_specs": {}, "dependencies": []},
+      {"dataset_id":"raw_staturgence_recherche_location*"     , "cluster_type": "small" , "run_type": "initial", "cluster_specs": {}, "dependencies": []},
+      {"dataset_id":"raw_staturgence_recherche_logtransaction", "cluster_type": "small" , "run_type": "initial", "cluster_specs": {}, "dependencies": []},
+      {"dataset_id":"raw_staturgence_recherche_patient*"      , "cluster_type": "small" , "run_type": "initial", "cluster_specs": {}, "dependencies": []},
+      {"dataset_id":"raw_staturgence_recherche_pilotage"      , "cluster_type": "small" , "run_type": "initial", "cluster_specs": {}, "dependencies": []},
+      {"dataset_id":"raw_staturgence_recherche_test"          , "cluster_type": "small" , "run_type": "initial", "cluster_specs": {}, "dependencies": []}
     ]
   }]
 


### PR DESCRIPTION
Also removed `publish_class` to prevent data from being erased from the database in case debugging is needed.