### PR TITLE
:wrench: chore: Run softlab test_result in its own dag

### DIFF
--- a/dags/config/red/ingestion/softlab_test_result_config.json
+++ b/dags/config/red/ingestion/softlab_test_result_config.json
@@ -1,0 +1,26 @@
+{
+    "concurrency": 2,
+    "schedule": "0 4 * * 3",
+    "timeout_hours": 5,
+    "steps": [{
+      "destination_zone": "red",
+      "destination_subzone": "raw",
+      "main_class": "bio.ferlab.ui.etl.red.raw.softlab.Main",
+      "publish_class": "bio.ferlab.ui.etl.red.raw.UpdateLog",
+      "schemas": ["softlab"],
+      "datasets":
+      [
+        {"dataset_id": "raw_softlab_v_p_lab_test_result", "cluster_type": "large",  "run_type": "default", "cluster_specs": {}, "dependencies": []}
+      ]
+    },{
+      "destination_zone": "yellow",
+      "destination_subzone": "anonymized",
+      "main_class": "bio.ferlab.ui.etl.yellow.anonymized.Main",
+      "publish_class": "",
+      "schemas": [],
+      "datasets":
+      [
+        {"dataset_id": "anonymized_softlab_v_p_lab_test_result", "cluster_type": "large",  "run_type": "default", "cluster_specs": {}, "dependencies": []}
+      ]
+    }]
+  }

--- a/dags/config/yellow/anonymized/softlab_config.json
+++ b/dags/config/yellow/anonymized/softlab_config.json
@@ -14,9 +14,7 @@
         {"dataset_id": "anonymized_softlab_v_p_lab_message"    , "cluster_type": "medium", "run_type": "initial", "cluster_specs": {}, "dependencies": []},
         {"dataset_id": "anonymized_softlab_v_p_lab_o*"         , "cluster_type": "medium", "run_type": "initial", "cluster_specs": {}, "dependencies": []},
         {"dataset_id": "anonymized_softlab_v_p_lab_patient"    , "cluster_type": "small" , "run_type": "initial", "cluster_specs": {}, "dependencies": []},
-        {"dataset_id": "anonymized_softlab_v_p_lab_s*"         , "cluster_type": "medium", "run_type": "initial", "cluster_specs": {}, "dependencies": []},
-        {"dataset_id": "anonymized_softlab_v_p_lab_test_result", "cluster_type": "large",  "run_type": "default", "cluster_specs": {}, "dependencies": []},
-        {"dataset_id": "anonymized_softmic_v_p_mic_*"          , "cluster_type": "medium", "run_type": "initial", "cluster_specs": {}, "dependencies": []}
+        {"dataset_id": "anonymized_softlab_v_p_lab_s*"         , "cluster_type": "medium", "run_type": "initial", "cluster_specs": {}, "dependencies": []}
       ]
     }]
   


### PR DESCRIPTION
* Run softlab_v_p_lab_result in its own dag since we ingest it from integration_ui db and not talend
* Remove softmic anonymization from softlab dag