### PR TITLE
:white_check_mark: fix: Remove opera vshoraire tests

### DIFF
--- a/dags/config/red/curated/opera_config.json
+++ b/dags/config/red/curated/opera_config.json
@@ -74,8 +74,6 @@
         "anonymized_opera_vscdj",
         "anonymized_opera_vsdelta_requete*",
         "anonymized_opera_vsetats",
-        "anonymized_opera_vshoraire_salles",
-        "anonymized_opera_vshoraire_blocstemps",
         "anonymized_opera_vsinfo_tracabilite*",
         "anonymized_opera_vsinterventions_plan",
         "anonymized_opera_vslog_transactions",


### PR DESCRIPTION
We have decided to stop checking the partition counts for opera vshoraire tables, as some rows may be deleted every other week. This is expected behavior, as scheduled surgeries can sometimes be canceled.