### PR TITLE
:recycle: refactor: Simplify anonymized participant index DAG

### DIFF
--- a/dags/anonymized_participant_index.py
+++ b/dags/anonymized_participant_index.py
@@ -1,94 +1,66 @@
 """
 Participant index anonymization DAG
 """
-# pylint: disable=missing-function-docstring, duplicate-code
+# pylint: disable=missing-function-docstring, duplicate-code, expression-not-assigned
 from datetime import timedelta, datetime
 
 from airflow import DAG
 from airflow.models import Param
 
-from lib.config import config_file, jar, version, spark_failure_msg, default_args, default_params
+from lib.config import config_file, jar, spark_failure_msg, default_args
+from lib.operators.spark import SparkOperator
 from lib.slack import Slack
-from spark_operators import setup_dag
+from lib.tasks.notify import start, end
 
-config = {
-    "concurrency": 2,
-    "schedule": None,
-    "timeout_hours": 1,
-    "steps": [{
-        "destination_zone": "yellow",
-        "destination_subzone": "anonymized",
-        "main_class": "bio.ferlab.ui.etl.yellow.anonymized.Main",
-        "multiple_main_methods": False,
-        "publish_class": "",
-        "schemas": [],
-        "pre_tests": [],
-        "datasets": [
-            {"dataset_id": "anonymized_unic_participant_index_atoepilot"                                          , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_barsop00_cesarienne_avec_infection"                 , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_barsop00_cesarienne_planifiee"                      , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_barsop00_cesarienne_urgente"                        , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_cardiopathie"                                       , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_coprema"                                            , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_ebv_sot_coeur"                                      , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_ebv_sot_foie"                                       , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_ebv_sot_rein"                                       , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_ivado_prf3_biopsie_foie_2023"                       , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_ivado_prf3_biopsie_foie2_2023"                      , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_ivado_prf3_steatose_hepatique"                      , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_monchemin"                                          , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_mdc_atoe"                                           , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_pedicss"                                            , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_picaso"                                             , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_picaso_inclusion_diagnosis_treatmentplan_2012_2022" , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_picaso_inclusion_diagnosis_treatmentplan_28_10_2024", "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_picaso_merge_diagnosis_treatmentplan_2012_2022"     , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_picaso_merge_diagnosis_treatmentplan_28_10_2024"    , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_picaso_patient_cart"                                , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_pragmatiq_study_id_mapping"                         , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_predisepsis"                                        , "cluster_type": "small" , "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_registre_cardiopathie_bebe"                         , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_registre_cardiopathie_maman"                        , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_resppa"                                             , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_signature"                                          , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_signature_triceps"                                  , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-            {"dataset_id": "anonymized_unic_participant_index_simapp"                                             , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
+DOC = """
+# Anonymized Participant Index DAG
 
-            {"dataset_id": "anonymized_unic_physician_index_bronchiolite"                                         , "cluster_type": "xsmall", "run_type": "default", "cluster_specs": {}, "dependencies": []},
-        ],
-        "optimize" : [],
-        "post_tests": []
-    }]
-}
+DAG pour l'anonymisation des index de participants des projets de recherche.
 
-# Add extra param
-params = default_params.copy()
-params.update({"dataset_id": Param("*", type="string")})
+### Description
+Ce DAG prend en entrée la destination à anonymiser et lance l'ETL d'anonymisation pour cette destination.
+
+### Configuration
+* Paramètre `branch` : Branche du jar à utiliser (ex. `master`)
+* Paramètre `destination` : Dataset ID de la destination à anonymiser (ex. `anonymized_unic_participant_index_coprema`)
+* Paramètre `run_type` : Type d'exécution de l'ETL (ex. `default`, `initial`)
+"""
 
 with DAG(
-    dag_id="anonymized_participant_index",
-    schedule_interval=config['schedule'],
-    params=params,
-    default_args=default_args,
-    start_date=datetime(2021, 1, 1),
-    concurrency=config['concurrency'],
-    catchup=False,
-    tags=["anonymized"],
-    dagrun_timeout=timedelta(hours=config['timeout_hours']),
-    is_paused_upon_creation=True,
-    on_failure_callback=Slack.notify_dag_failure  # Should send notification to Slack when DAG exceeds timeout
+        dag_id="anonymized_participant_index",
+        schedule=None,
+        params={
+            "branch": Param("master", type="string"),
+            "destination": Param("anonymized_unic_participant_index_", type="string"),
+            "run_type": Param("default", enum=["default", "initial"]),
+        },
+        default_args=default_args,
+        doc_md=DOC,
+        start_date=datetime(2021, 1, 1),
+        concurrency=2,
+        catchup=False,
+        tags=["anonymized"],
+        dagrun_timeout=timedelta(hours=1),
+        is_paused_upon_creation=True,
+        on_failure_callback=Slack.notify_dag_failure  # Should send notification to Slack when DAG exceeds timeout
 ) as dag:
+    def run_type() -> str:
+        return "{{ params.run_type }}"
 
-    def skip_task() -> str:
-        return "{% if params.dataset_id == '*' or params.dataset_id == task.task_id.split('.')[1] %}{% else %}yes{% endif %}"
 
-    setup_dag(
-        dag=dag,
-        dag_config=config,
-        config_file=config_file,
-        jar=jar,
-        resource="participant_index",
-        version=version,
+    def destination() -> str:
+        return "{{ params.destination }}"
+
+
+    anonymized_task = SparkOperator(
+        task_id="anonymized_participant_index",
+        name="anonymized-participant-index",
+        arguments=[config_file, run_type(), destination()],
+        zone="yellow",
+        spark_class="bio.ferlab.ui.etl.yellow.anonymized.Main",
+        spark_jar=jar,
         spark_failure_msg=spark_failure_msg,
-        skip_task=skip_task()
+        spark_config="xsmall-etl",
     )
+
+    start() >> anonymized_task >> end()


### PR DESCRIPTION
Previously, every time we wanted to anonymize a new participant index, we had to manually add it to the DAG’s `config` dict. This PR introduces a `destination` parameter, which allows any dataset ID defined in the `UnicMappings` file of `unic-etl` to be anonymized dynamically, without modifying the DAG code.