### PR TITLE
:bug: fix(os_index_dags): Properly map os env to pg env

### DIFF
--- a/dags/lib/opensearch.py
+++ b/dags/lib/opensearch.py
@@ -2,20 +2,31 @@ from enum import Enum
 
 from airflow.models import Variable
 
+from lib.postgres import PostgresEnv
+
 
 class OpensearchEnv(Enum):
     QA = 'qa'
     PROD = 'prod'
 
+
+"""
+Opensearch environment to Postgres environment mapping
+"""
+os_env_pg_env_mapping: dict = {
+    OpensearchEnv.PROD: PostgresEnv.PROD,
+    OpensearchEnv.QA: PostgresEnv.DEV
+}
+
 os_port = '9200'
-os_credentials_username_key='username'
-os_credentials_password_key='password'
+os_credentials_username_key = 'username'
+os_credentials_password_key = 'password'
 os_cert_filename = 'ca.crt'
 
 # Opensearch prod configs
 os_prod_url = 'https://workers.opensearch.unic.sainte-justine.intranet'
-os_prod_credentials_secret ='opensearch-dags-credentials'
-os_prod_cert_secret='unic-prod-opensearch-ca-certificate'
+os_prod_credentials_secret = 'opensearch-dags-credentials'
+os_prod_cert_secret = 'unic-prod-opensearch-ca-certificate'
 os_prod_username = Variable.get('os_prod_username', None)
 os_prod_password = Variable.get('os_prod_password', None)
 os_prod_cert = Variable.get('os_prod_ca_certificate', None)
@@ -23,9 +34,9 @@ os_prod_cert_path = '/tmp/ca/os/prod/'
 
 # Opensearch qa configs
 os_qa_url = 'https://workers.opensearch.qa.unic.sainte-justine.intranet'
-os_qa_credentials_secret ='opensearch-qa-dags-credentials'
-os_qa_cert_secret ='unic-prod-opensearch-qa-ca-certificate'
+os_qa_credentials_secret = 'opensearch-qa-dags-credentials'
+os_qa_cert_secret = 'unic-prod-opensearch-qa-ca-certificate'
 os_qa_username = Variable.get('os_qa_username', None)
 os_qa_password = Variable.get('os_qa_password', None)
-os_qa_cert= Variable.get('os_qa_ca_certificate', None)
+os_qa_cert = Variable.get('os_qa_ca_certificate', None)
 os_qa_cert_path = '/tmp/ca/os/qa/'

--- a/dags/os_index_dags.py
+++ b/dags/os_index_dags.py
@@ -12,16 +12,15 @@ from airflow.decorators import task_group
 from airflow.models import Param
 from airflow.utils.trigger_rule import TriggerRule
 
-from lib.postgres import PostgresEnv
-from lib.opensearch import OpensearchEnv, os_port, os_qa_url, os_prod_url
 from lib.config import jar, spark_failure_msg
+from lib.opensearch import OpensearchEnv, os_port, os_qa_url, os_prod_url, os_env_pg_env_mapping
 # from lib.slack import Slack
 from lib.tasks.notify import start, end
 from lib.tasks.opensearch import load_index, publish_index
 
+
 def load_index_arguments(release_id: str, os_url: str, template_filename: str, os_env_name: str, pg_env_name: str,
                          alias: str) -> List[str]:
-
     return [
         "--env", pg_env_name,
         "--osurl", os_url,
@@ -33,8 +32,8 @@ def load_index_arguments(release_id: str, os_url: str, template_filename: str, o
         "--config", "config/prod.conf"
     ]
 
-def publish_index_arguments(release_id: str, os_url: str, alias: str) -> List[str]:
 
+def publish_index_arguments(release_id: str, os_url: str, alias: str) -> List[str]:
     return [
         "--osurl", os_url,
         "--osport", os_port,
@@ -42,8 +41,10 @@ def publish_index_arguments(release_id: str, os_url: str, alias: str) -> List[st
         "--alias", alias
     ]
 
+
 def get_release_id() -> str:
     return '{{ params.release_id or "" }}'
+
 
 # Update default args
 args = {
@@ -53,9 +54,8 @@ args = {
 }
 
 for os_env in OpensearchEnv:
-
-    os_env_name = os_env.value
-    pg_env_name = PostgresEnv.PROD.value
+    os_env_name: str = os_env.value
+    pg_env_name: str = os_env_pg_env_mapping[os_env].value
 
     doc = f"""
     # Load {pg_env_name} Index into OpenSeach {os_env_name} 


### PR DESCRIPTION
Previously, the Postgres PROD environment was hardcoded. This PR updates the logic to automatically use the appropriate Postgres environment based on the selected OpenSearch environment.