### PR TITLE
✨ feat(unic_publish_project): Added dictionary publishing, paths from unic-etl

### DIFF
--- a/dags/lib/groups/publish/publish.py
+++ b/dags/lib/groups/publish/publish.py
@@ -5,17 +5,33 @@ from lib.tasks.opensearch import prepare_index, load_index, publish_index, get_n
 from lib.tasks.notify import start, end
 from lib.config import PUBLISHED_BUCKET, YELLOW_MINIO_CONN_ID
 
-from lib.tasks.publish import get_resource_code, get_version_to_publish, get_include_dictionary, update_dict_current_version, publish_dictionary, get_publish_kwargs
+from lib.tasks.publish import get_resource_code, get_version_to_publish, get_include_dictionary, update_dict_current_version, publish_dictionary, set_publish_kwargs, extract_config_info
 from lib.tasks.excel import parquet_to_excel
+
 
 @task_group(group_id="publish_research_project")
 def publish_research_project(pg_conn_id: str, resource_code: str, version_to_publish: str, include_dictionary: bool) -> None:
 
-    update_dict_current_version(dict_version=version_to_publish, resource_code=resource_code, include_dictionary=include_dictionary, pg_conn_id=pg_conn_id) \
-    >> publish_dictionary(resource_code=resource_code, version_to_publish=version_to_publish, include_dictionary=include_dictionary, pg_conn_id=pg_conn_id) \
-    >> parquet_to_excel.override(task_id="publish_project_data").expand_kwargs(get_publish_kwargs(
+    dictionary_update_task = update_dict_current_version(dict_version=version_to_publish, resource_code=resource_code, include_dictionary=include_dictionary, pg_conn_id=pg_conn_id)
+
+    #Extracting config info relevant for this resource code
+    config_info = extract_config_info(resource_code=resource_code,
+                                      version_to_publish=version_to_publish,
+                                      minio_conn_id=YELLOW_MINIO_CONN_ID,
+                                      bucket=PUBLISHED_BUCKET)
+
+    dict_task = publish_dictionary(
         resource_code=resource_code,
         version_to_publish=version_to_publish,
-        minio_conn_id=YELLOW_MINIO_CONN_ID,
-        bucket=PUBLISHED_BUCKET
+        include_dictionary=include_dictionary,
+        pg_conn_id=pg_conn_id,
+        config=config_info)
+
+    publish_task = parquet_to_excel.override(task_id="publish_project_data").expand_kwargs(set_publish_kwargs(
+        resource_code=resource_code,
+        version_to_publish=version_to_publish,
+        config=config_info,
     ))
+
+    #Set up task order
+    start() >> dictionary_update_task >> config_info >> dict_task >> publish_task >> end()

--- a/dags/lib/hocon_parsing.py
+++ b/dags/lib/hocon_parsing.py
@@ -81,3 +81,26 @@ def get_bucket_id(source_id: str, config: dict) -> str:
             return storage["path"].split("/")[2] # Extract bucket name from s3 path
 
     raise AirflowFailException(f"Storage ID {storageid} not found in configuration.")
+
+def get_dataset_published_path(
+        source_id: str,
+        config: dict
+) -> str:
+    """
+    Get the published path for a dataset from the Spark HOCON configuration.
+    The path comes without the extension for the output file.
+
+    :param source_id: The dataset ID to look up.
+    :param config: The parsed HOCON configuration.
+    :return: The published path associated with the dataset ID.
+    """
+    # Imports made inside function due to using PythonVirtualenvOperator
+    from airflow.exceptions import AirflowFailException
+
+    sources = config.get("datalake.sources")
+
+    for source in sources:
+        if source["id"] == source_id:
+            return source["path"]
+
+    raise AirflowFailException(f"Dataset ID {source_id} not found in configuration.")

--- a/dags/lib/publish_utils.py
+++ b/dags/lib/publish_utils.py
@@ -1,0 +1,37 @@
+from enum import Enum
+import logging
+
+from airflow.exceptions import AirflowFailException
+
+
+class FileType(Enum):
+    """
+    Enum for output types.
+    """
+    EXCEL = ".xlsx"
+    PARQUET = ".parquet"
+
+def add_extension_to_path(path: str, output_type: FileType) -> str:
+    """
+    Append the extension to the path based on the output type.
+
+    :param path: The base path to which the extension will be added, must NOT end with any extension.
+    If the given base path has an extension, the new extension will be appended to it.
+    :param output_type: The type of output, which determines the extension to append.
+    """
+    return f"{path}{output_type.value}"
+
+def print_extracted_config(resource_code: str, version_to_publish: str, mini_config: dict) -> None:
+    # Print a nice summary of the configuration
+    logging.info(f"Configuration for {resource_code} (version {version_to_publish}):")
+    logging.info(f"Input bucket: {mini_config['input_bucket']}")
+    logging.info(f"Has clinical data: {mini_config['has_clinical']}")
+    logging.info(f"Has nominative data: {mini_config['has_nominative']}")
+
+    # Print details about each table
+    logging.info("Tables to be published:")
+    for source_id, source_info in mini_config['sources'].items():
+        logging.info(f"  - {source_info['table']}:")
+        logging.info(f"    Source ID: {source_id}")
+        logging.info(f"    Output bucket: {source_info['output_bucket']}")
+        logging.info(f"    Output path: {source_info['output_path']}")

--- a/dags/lib/tasks/publish.py
+++ b/dags/lib/tasks/publish.py
@@ -147,7 +147,8 @@ def extract_config_info(
             "table": table,
             "minio_conn_id": minio_conn_id
         }
-    print_extracted_config(resource_code, version_to_publish, mini_config)
+    # Uncomment to print the extracted configuration
+    #print_extracted_config(resource_code, version_to_publish, mini_config)
     return mini_config
 
 


### PR DESCRIPTION
- Refactored config parsing into separate task in order to pass information to multiple tasks.
- Paths of the tables to publish are now controlled in unic-etl, and passed along here
- Updated publish_dictionary to make it functional again