### PR TITLE
:bug: UNIC-1986 Adjusted date argument to consider Timezone in quanum

### DIFF
--- a/dags/curated_quanumchartmaxx.py
+++ b/dags/curated_quanumchartmaxx.py
@@ -90,7 +90,7 @@ def generate_spark_arguments(destination: str, pass_date: bool, steps: str = "de
 
     if pass_date:
         arguments.append("--date")
-        arguments.append("{{ ds }}")
+        arguments.append("{{ data_interval_start.in_timezone('America/Montreal').format('YYYY-MM-DD') }}")
 
     return arguments
 


### PR DESCRIPTION
Tested on both EST and EDT.

the previously used {{ ds }} had the inconvenience of exclusively being attributed to UTC. This situation was made evident with the current dag that runs at 19:00 EDT (23:00 UTC) in the summer and 19:00EST (00:00 UTC / Next day) in the winter. 

pendulum module was already used to be able to consider timezone as a whole. However, the value specific passed as an argument was still being used as UTc and thus the issue remained. 

the proposed fix is an alternative to ds which is data_interval_start with an emphasis of time zone parameter. All use was tested and functionnaly mimics previous implementation for quanum