### PR TITLE
:sparkles: feat: UNIC-2031 Add IntervalTimetable for start_date-anchored interval schedules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,6 @@ jobs:
       - run: |
          pip install "apache-airflow==2.7.1" --constraint https://raw.githubusercontent.com/apache/airflow/constraints-2.7.1/constraints-3.8.txt
          pip install -r requirements.txt
-         pylint --load-plugins=pylint_airflow --fail-under=10.0 */**.py
+         pylint --load-plugins=pylint_airflow --fail-under=10.0 */**.py plugins/timetables/**.py tests/plugins/**.py
 
 

--- a/plugins/timetables/__init__.py
+++ b/plugins/timetables/__init__.py
@@ -1,0 +1,4 @@
+"""Custom Airflow timetables for unic-dag."""
+from timetables.interval import IntervalTimetable
+
+__all__ = ["IntervalTimetable"]

--- a/plugins/timetables/interval.py
+++ b/plugins/timetables/interval.py
@@ -16,6 +16,15 @@ from ``TimeRestriction.earliest`` on each scheduler tick) on the grid
 re-align the next run on the next scheduler tick - no history clearing
 required.
 
+DST behaviour
+-------------
+The grid is computed in naive (DST-free) wall-clock space and then localized to
+the ``start_date`` timezone, so the *wall-clock* run time is held constant across
+daylight-saving transitions: a schedule anchored at 03:00 keeps firing at 03:00
+local year-round, exactly like a cron schedule. This differs from a plain
+``timedelta`` schedule (``DeltaDataIntervalTimetable``), which adds an absolute
+duration and therefore drifts the run by an hour after each DST transition.
+
 Usage
 -----
 Requires ``start_date=`` set on the DAG itself (not just on tasks). ::
@@ -46,7 +55,6 @@ from pendulum import DateTime
 
 from airflow.exceptions import AirflowTimetableInvalid
 from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, Timetable
-from airflow.timetables.interval import DeltaDataIntervalTimetable
 
 
 class IntervalTimetable(Timetable):
@@ -97,19 +105,39 @@ class IntervalTimetable(Timetable):
     def deserialize(cls, data: dict[str, Any]) -> IntervalTimetable:
         return cls(interval=timedelta(seconds=data["interval"]))
 
+    @staticmethod
+    def _localize(naive: DateTime, timezone) -> DateTime:
+        """Attach ``timezone`` to a naive wall-clock ``DateTime``, picking the correct UTC offset."""
+        return timezone.convert(naive)
+
+    def _grid_slot(self, anchor: DateTime, k: int) -> DateTime:
+        """The ``k``-th schedule slot: ``anchor``'s wall clock advanced ``k`` intervals.
+
+        Arithmetic is done in naive (DST-free) wall-clock space and then localized,
+        so the *wall-clock* time is held constant across DST transitions -- a 03:00
+        schedule keeps firing at 03:00, like cron -- rather than holding the absolute
+        elapsed duration (which would drift the run by an hour after each transition).
+        """
+        return self._localize(anchor.naive() + k * self._interval, anchor.timezone)
+
     def _slot_at(self, instant: DateTime, anchor: DateTime, round_fn) -> DateTime:
-        """Return ``anchor + k * interval`` where ``k = round_fn(elapsed / interval)``.
+        """Return grid slot ``k`` where ``k = round_fn(wall_clock_elapsed / interval)``.
 
         Pass ``math.floor`` to land on the slot at-or-before ``instant``, or
         ``math.ceil`` to land on the slot at-or-after. Clamped to ``anchor``
         when ``instant`` is at or before the anchor (no earlier slot exists).
+
+        ``elapsed`` is measured in naive wall-clock space (``instant`` rendered in
+        the anchor's timezone, tz stripped) so the division lands on an exact
+        integer ``k`` at grid points regardless of any DST transition in between.
         """
         if instant <= anchor:
             return anchor
-        elapsed = (instant - anchor).total_seconds()
+        timezone = anchor.timezone
+        elapsed = (instant.in_timezone(timezone).naive() - anchor.naive()).total_seconds()
         period = self._interval.total_seconds()
         k = round_fn(elapsed / period)
-        return anchor + k * self._interval
+        return self._grid_slot(anchor, k)
 
     def _align_to_prev(self, instant: DateTime, anchor: DateTime) -> DateTime:
         """Largest (``floor``) ``anchor + k*interval`` slot ``<= instant``.
@@ -138,7 +166,7 @@ class IntervalTimetable(Timetable):
         in progress, return ``anchor`` so the first run is scheduled.
         """
         now = DateTime.utcnow()
-        if now < anchor + self._interval:
+        if now < self._grid_slot(anchor, 1):
             return anchor
         return self._align_to_prev(now - self._interval, anchor)
 
@@ -177,5 +205,8 @@ class IntervalTimetable(Timetable):
 
         if restriction.latest is not None and start > restriction.latest:
             return None
-        end = start + self._interval
+        # Advance one interval on the wall-clock grid (not absolute seconds) so the
+        # interval end holds local time across a DST transition. ``start`` is always
+        # a grid slot, so this lands on the next slot and intervals stay contiguous.
+        end = self._localize(start.naive() + self._interval, anchor.timezone)
         return DagRunInfo.interval(start=start, end=end)

--- a/plugins/timetables/interval.py
+++ b/plugins/timetables/interval.py
@@ -1,0 +1,181 @@
+"""Custom Airflow timetable that anchors a fixed-interval schedule on the DAG's ``start_date``.
+
+Background
+----------
+Airflow's stock ``DeltaDataIntervalTimetable`` (used when ``schedule_interval``
+is a ``datetime.timedelta``) computes the next run by chaining off the
+previous run's data-interval end: ``next.start = last.end``. Once a DAG has
+any history, the schedule is anchored on the most recent actual run rather
+than on the DAG's ``start_date``. As a result, editing ``start_date`` to
+shift the run time of a DAG already in production does NOT move the schedule
+- the only workaround has been clearing DAG history in the Airflow UI.
+
+``IntervalTimetable`` recomputes every run from the DAG's ``start_date`` (read
+from ``TimeRestriction.earliest`` on each scheduler tick) on the grid
+``start_date + k * interval``. Editing ``start_date`` in code is enough to
+re-align the next run on the next scheduler tick - no history clearing
+required.
+
+Usage
+-----
+Requires ``start_date=`` set on the DAG itself (not just on tasks). ::
+
+    from datetime import timedelta
+    import pendulum
+    from timetables import IntervalTimetable
+
+    dag = DAG(
+        dag_id="curated_cscmed",
+        schedule=IntervalTimetable(interval=timedelta(weeks=4)),
+        start_date=pendulum.datetime(2026, 3, 13, 3, tz="America/Montreal"),
+        catchup=False,
+        ...
+    )
+
+To shift the run time later, edit only ``start_date=`` on the DAG. The
+timetable re-anchors on the next scheduler tick.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import timedelta
+from typing import Any
+
+from pendulum import DateTime
+
+from airflow.exceptions import AirflowTimetableInvalid
+from airflow.timetables.base import DagRunInfo, DataInterval, TimeRestriction, Timetable
+from airflow.timetables.interval import DeltaDataIntervalTimetable
+
+
+class IntervalTimetable(Timetable):
+    """Schedule on the grid ``DAG.start_date + k * interval`` for non-negative ``k``.
+
+    Example grid with ``start_date = 2026-03-13 03:00`` and ``interval = 4 weeks``:
+
+    ===  =================
+    k    slot
+    ===  =================
+    0    2026-03-13 03:00
+    1    2026-04-10 03:00
+    2    2026-05-08 03:00
+    3    2026-06-05 03:00
+    ===  =================
+
+    Alignment turns an arbitrary instant into a slot index ``k`` by computing
+    ``elapsed / interval`` and rounding -- ``floor`` for the slot at-or-before
+    the instant, ``ceil`` for the slot at-or-after.
+    """
+
+    description: str = "Every fixed interval, anchored on the DAG's start_date."
+
+    def __init__(self, interval: timedelta) -> None:
+        if not isinstance(interval, timedelta) or interval <= timedelta(0):
+            raise AirflowTimetableInvalid(f"interval must be a positive timedelta, got {interval!r}")
+        self._interval = interval
+        self.description = f"Schedule: every {interval}, anchored on the DAG's start_date."
+
+    @property
+    def summary(self) -> str:
+        return f"every {self._interval}"
+
+    def __eq__(self, other: Any) -> bool:
+        """
+        Return if the intervals match.
+
+        This is only for testing purposes and should not be relied on otherwise.
+        """
+        if not isinstance(other, IntervalTimetable):
+            return NotImplemented
+        return self._interval == other._interval
+
+    def serialize(self) -> dict[str, Any]:
+        return {"interval": self._interval.total_seconds()}
+
+    @classmethod
+    def deserialize(cls, data: dict[str, Any]) -> IntervalTimetable:
+        return cls(interval=timedelta(seconds=data["interval"]))
+
+    def _slot_at(self, instant: DateTime, anchor: DateTime, round_fn) -> DateTime:
+        """Return ``anchor + k * interval`` where ``k = round_fn(elapsed / interval)``.
+
+        Pass ``math.floor`` to land on the slot at-or-before ``instant``, or
+        ``math.ceil`` to land on the slot at-or-after. Clamped to ``anchor``
+        when ``instant`` is at or before the anchor (no earlier slot exists).
+        """
+        if instant <= anchor:
+            return anchor
+        elapsed = (instant - anchor).total_seconds()
+        period = self._interval.total_seconds()
+        k = round_fn(elapsed / period)
+        return anchor + k * self._interval
+
+    def _align_to_prev(self, instant: DateTime, anchor: DateTime) -> DateTime:
+        """Largest (``floor``) ``anchor + k*interval`` slot ``<= instant``.
+
+        Example with ``anchor = 2026-03-13 03:00`` and ``interval = 4 weeks``:
+        an instant of ``2026-04-25 12:00`` is ``~1.55`` intervals past the
+        anchor, so ``floor`` picks ``k=1`` → ``2026-04-10 03:00``.
+        """
+        return self._slot_at(instant, anchor, math.floor)
+
+    def _align_to_next(self, instant: DateTime, anchor: DateTime) -> DateTime:
+        """Smallest (``ceil``) ``anchor + k*interval`` slot ``>= instant``.
+
+        Same example as ``_align_to_prev``: an instant of ``2026-04-25 12:00``
+        is ``~1.55`` intervals past the anchor, so ``ceil`` picks ``k=2`` →
+        ``2026-05-08 03:00``.
+        """
+        return self._slot_at(instant, anchor, math.ceil)
+
+    def _skip_to_latest(self, anchor: DateTime) -> DateTime:
+        """For ``catchup=False``: start of the most recently completed interval.
+
+        Mirrors ``CronDataIntervalTimetable._skip_to_latest`` semantics: return
+        the start of the latest interval whose ``end`` is ``<= now`` so the
+        corresponding DagRun fires immediately. If the first interval is still
+        in progress, return ``anchor`` so the first run is scheduled.
+        """
+        now = DateTime.utcnow()
+        if now < anchor + self._interval:
+            return anchor
+        return self._align_to_prev(now - self._interval, anchor)
+
+    def infer_manual_data_interval(self, *, run_after: DateTime) -> DataInterval:
+        # No anchor available here, so fall back to the delta semantic used by
+        # DeltaDataIntervalTimetable: the interval ends exactly at run_after.
+        return DataInterval(start=run_after - self._interval, end=run_after)
+
+    def next_dagrun_info(
+            self,
+            *,
+            last_automated_data_interval: DataInterval | None,
+            restriction: TimeRestriction,
+    ) -> DagRunInfo | None:
+        anchor = restriction.earliest  # = DAG.start_date
+        if anchor is None:
+            return None
+
+        # catchup=True: iterate slot-by-slot from start_date.
+        # catchup=False: skip straight to the most-recently-completed slot.
+        if restriction.catchup:
+            earliest = anchor
+        else:
+            earliest = self._skip_to_latest(anchor)
+
+        if last_automated_data_interval is None:
+            start = earliest
+        else:
+            # Re-anchor the previous run's end onto the current grid -- this
+            # is what lets a start_date edit shift the schedule without
+            # clearing DAG history.
+            align_last_end = self._align_to_prev(
+                last_automated_data_interval.end, anchor
+            )
+            start = max(align_last_end, earliest)
+
+        if restriction.latest is not None and start > restriction.latest:
+            return None
+        end = start + self._interval
+        return DagRunInfo.interval(start=start, end=end)

--- a/plugins/unic_plugins.py
+++ b/plugins/unic_plugins.py
@@ -1,0 +1,14 @@
+"""Airflow plugin registrations for unic-dag."""
+
+from __future__ import annotations
+
+from airflow.plugins_manager import AirflowPlugin
+
+from timetables.interval import IntervalTimetable
+
+
+class UnicPlugins(AirflowPlugin):
+    """Registers custom timetables so Airflow can deserialize them from the metadata DB."""
+
+    name = "unic_plugins"
+    timetables = [IntervalTimetable]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+pythonpath = . dags plugins
+testpaths = tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ pandas~=2.0.3
 typing_extensions
 psycopg2-binary~=2.9.7
 pendulum~=2.1.2
+freezegun~=1.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,5 @@ pandas~=2.0.3
 typing_extensions
 psycopg2-binary~=2.9.7
 pendulum~=2.1.2
+pytest~=7.4.1
 freezegun~=1.5.0

--- a/tests/plugins/test_interval.py
+++ b/tests/plugins/test_interval.py
@@ -120,6 +120,53 @@ def test_next_dagrun_info_realigns_after_anchor_shift():
     )
 
 
+# --- next_dagrun_info: daylight-saving-time stability -------------------
+# A 03:00 schedule must keep firing at 03:00 *local* across DST transitions
+# (like a cron schedule), not drift by an hour the way absolute-duration
+# (timedelta) arithmetic does. 2026 transitions in America/Montreal:
+# spring-forward Mar 8, fall-back Nov 1.
+DST_SUMMER_ANCHOR = pendulum.datetime(2026, 9, 4, 3, 0, 0, tz=TZ)  # 03:00 EDT
+DST_WINTER_ANCHOR = pendulum.datetime(2026, 2, 13, 3, 0, 0, tz=TZ)  # 03:00 EST
+
+
+def test_next_dagrun_info_holds_wall_clock_across_fall_back():
+    """An interval whose end crosses fall-back (Nov 1) lands at 03:00, not 02:00."""
+    last_end = pendulum.datetime(2026, 10, 30, 3, 0, 0, tz=TZ)  # slot before fall-back
+    info = _tt().next_dagrun_info(
+        last_automated_data_interval=DataInterval(start=last_end - INTERVAL, end=last_end),
+        restriction=_restriction(earliest=DST_SUMMER_ANCHOR),
+    )
+    assert info is not None
+    assert info.data_interval.end.hour == 3
+    assert info.data_interval.end == pendulum.datetime(2026, 11, 27, 3, 0, 0, tz=TZ)
+
+
+def test_next_dagrun_info_holds_wall_clock_after_fall_back():
+    """Both endpoints of an interval entirely after fall-back stay at 03:00 local."""
+    last_end = pendulum.datetime(2026, 11, 27, 3, 0, 0, tz=TZ)  # 03:00 EST
+    info = _tt().next_dagrun_info(
+        last_automated_data_interval=DataInterval(start=last_end - INTERVAL, end=last_end),
+        restriction=_restriction(earliest=DST_SUMMER_ANCHOR),
+    )
+    assert info is not None
+    assert info.data_interval.start.hour == 3
+    assert info.data_interval.start == last_end
+    assert info.data_interval.end.hour == 3
+    assert info.data_interval.end == pendulum.datetime(2026, 12, 25, 3, 0, 0, tz=TZ)
+
+
+def test_next_dagrun_info_holds_wall_clock_across_spring_forward():
+    """An interval whose end crosses spring-forward (Mar 8) lands at 03:00, not 04:00."""
+    last_end = DST_WINTER_ANCHOR  # 2026-02-13 03:00 EST, the anchor slot
+    info = _tt().next_dagrun_info(
+        last_automated_data_interval=DataInterval(start=last_end - INTERVAL, end=last_end),
+        restriction=_restriction(earliest=DST_WINTER_ANCHOR),
+    )
+    assert info is not None
+    assert info.data_interval.end.hour == 3
+    assert info.data_interval.end == pendulum.datetime(2026, 3, 13, 3, 0, 0, tz=TZ)
+
+
 # --- next_dagrun_info: catchup=True, first run --------------------------
 def test_next_dagrun_info_first_run_catchup_true_starts_at_anchor():
     info = _tt().next_dagrun_info(

--- a/tests/plugins/test_interval.py
+++ b/tests/plugins/test_interval.py
@@ -1,0 +1,196 @@
+"""Unit tests for IntervalTimetable."""
+# pylint: disable=missing-function-docstring,protected-access,invalid-name
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pendulum
+import pytest
+from freezegun import freeze_time
+
+from airflow.exceptions import AirflowTimetableInvalid
+from airflow.timetables.base import DataInterval, TimeRestriction
+
+from timetables.interval import IntervalTimetable
+
+TZ = pendulum.timezone("America/Montreal")
+START = pendulum.datetime(2026, 3, 13, 3, 0, 0, tz=TZ)
+INTERVAL = timedelta(weeks=4)
+
+
+def _tt() -> IntervalTimetable:
+    return IntervalTimetable(interval=INTERVAL)
+
+
+def _restriction(earliest=START, latest=None, catchup=True) -> TimeRestriction:
+    return TimeRestriction(earliest=earliest, latest=latest, catchup=catchup)
+
+
+# --- construction --------------------------------------------------------
+def test_construction_stores_interval():
+    tt = _tt()
+    assert tt._interval == INTERVAL
+
+
+@pytest.mark.parametrize("bad_interval", [timedelta(0), timedelta(seconds=-1)])
+def test_construction_rejects_non_positive_interval(bad_interval):
+    with pytest.raises(AirflowTimetableInvalid):
+        IntervalTimetable(interval=bad_interval)
+
+
+def test_construction_rejects_non_timedelta_interval():
+    with pytest.raises(AirflowTimetableInvalid):
+        IntervalTimetable(interval=42)  # type: ignore[arg-type]
+
+
+# --- alignment helpers (anchor passed explicitly) -----------------------
+@pytest.mark.parametrize(
+    "instant,expected",
+    [
+        (START, START),
+        (START - timedelta(days=1), START),
+        (START + INTERVAL - timedelta(seconds=1), START),
+        (START + INTERVAL, START + INTERVAL),
+        (START + 2 * INTERVAL - timedelta(seconds=1), START + INTERVAL),
+        (START + 5 * INTERVAL, START + 5 * INTERVAL),
+    ],
+)
+def test_align_to_prev(instant, expected):
+    assert _tt()._align_to_prev(instant, anchor=START) == expected
+
+
+@pytest.mark.parametrize(
+    "instant,expected",
+    [
+        (START, START),
+        (START - timedelta(days=1), START),
+        (START + timedelta(seconds=1), START + INTERVAL),
+        (START + INTERVAL, START + INTERVAL),
+        (START + INTERVAL + timedelta(seconds=1), START + 2 * INTERVAL),
+        (START + 5 * INTERVAL, START + 5 * INTERVAL),
+    ],
+)
+def test_align_to_next(instant, expected):
+    assert _tt()._align_to_next(instant, anchor=START) == expected
+
+
+# --- infer_manual_data_interval -----------------------------------------
+def test_infer_manual_data_interval_uses_delta_semantic():
+    """Manual triggers have no anchor info, so the interval ends at run_after."""
+    run_after = START + INTERVAL + timedelta(days=3)
+    di = _tt().infer_manual_data_interval(run_after=run_after)
+    assert di == DataInterval(start=run_after - INTERVAL, end=run_after)
+
+
+# --- next_dagrun_info: chaining off last_automated_data_interval --------
+def test_next_dagrun_info_chains_from_aligned_last_end():
+    last = DataInterval(start=START, end=START + INTERVAL)
+    info = _tt().next_dagrun_info(
+        last_automated_data_interval=last,
+        restriction=_restriction(),
+    )
+    assert info is not None
+    assert info.data_interval == DataInterval(
+        start=START + INTERVAL, end=START + 2 * INTERVAL
+    )
+
+
+def test_next_dagrun_info_realigns_after_anchor_shift():
+    """When the DAG's start_date is shifted, next slot re-anchors to the new grid.
+
+    Simulate a DAG that previously ran at 03:00 (last end = 2026-04-10 03:00),
+    then the user shifts the DAG's start_date to 04:00. The next run's data
+    interval end must align to the NEW grid (04:00), not chain off the old
+    03:00 end.
+    """
+    old_last_end = START + INTERVAL  # 2026-04-10 03:00
+    shifted_anchor = START.add(hours=1)  # 2026-03-13 04:00
+    info = _tt().next_dagrun_info(
+        last_automated_data_interval=DataInterval(start=START, end=old_last_end),
+        restriction=_restriction(earliest=shifted_anchor),
+    )
+    assert info is not None
+    # Grid is [shifted_anchor, shifted_anchor + INTERVAL, ...].
+    # _align_to_prev(2026-04-10 03:00 on the 04:00-anchored grid) lands on
+    # shifted_anchor (03:00 of Apr 10 is before 04:00 of Apr 10, so the
+    # previous aligned slot is shifted_anchor = 2026-03-13 04:00).
+    assert info.data_interval.end.hour == 4
+    assert info.data_interval == DataInterval(
+        start=shifted_anchor, end=shifted_anchor + INTERVAL
+    )
+
+
+# --- next_dagrun_info: catchup=True, first run --------------------------
+def test_next_dagrun_info_first_run_catchup_true_starts_at_anchor():
+    info = _tt().next_dagrun_info(
+        last_automated_data_interval=None,
+        restriction=_restriction(earliest=START, catchup=True),
+    )
+    assert info is not None
+    assert info.data_interval == DataInterval(start=START, end=START + INTERVAL)
+
+
+# --- next_dagrun_info: catchup=False ------------------------------------
+def test_next_dagrun_info_first_run_catchup_false_skips_to_latest_completed():
+    """catchup=False with no past run and anchor in the past should fire the
+    most recently completed interval (whose end has already passed)."""
+    # Freeze "now" two days past anchor + 3*INTERVAL (3 intervals completed).
+    frozen_now = START + 3 * INTERVAL + timedelta(days=2)
+    with freeze_time(frozen_now):
+        info = _tt().next_dagrun_info(
+            last_automated_data_interval=None,
+            restriction=_restriction(earliest=START, catchup=False),
+        )
+    assert info is not None
+    # Latest interval whose end <= now is [START + 2*INTERVAL, START + 3*INTERVAL].
+    assert info.data_interval == DataInterval(
+        start=START + 2 * INTERVAL, end=START + 3 * INTERVAL
+    )
+
+
+def test_next_dagrun_info_first_run_catchup_false_first_interval_in_progress():
+    """If now is before anchor + interval, the first interval hasn't ended;
+    schedule it at the anchor so run_after = anchor + interval (future)."""
+    frozen_now = START + timedelta(days=3)
+    with freeze_time(frozen_now):
+        info = _tt().next_dagrun_info(
+            last_automated_data_interval=None,
+            restriction=_restriction(earliest=START, catchup=False),
+        )
+    assert info is not None
+    assert info.data_interval == DataInterval(start=START, end=START + INTERVAL)
+
+
+# --- next_dagrun_info: edge cases ---------------------------------------
+def test_next_dagrun_info_returns_none_when_earliest_is_none():
+    info = _tt().next_dagrun_info(
+        last_automated_data_interval=None,
+        restriction=TimeRestriction(earliest=None, latest=None, catchup=True),
+    )
+    assert info is None
+
+
+def test_next_dagrun_info_returns_none_when_past_latest():
+    info = _tt().next_dagrun_info(
+        last_automated_data_interval=None,
+        restriction=_restriction(
+            earliest=START, latest=START - timedelta(days=1), catchup=True
+        ),
+    )
+    assert info is None
+
+
+# --- serialize / deserialize --------------------------------------------
+def test_serialize_round_trip():
+    original = _tt()
+    rebuilt = IntervalTimetable.deserialize(original.serialize())
+    assert rebuilt == original
+    assert rebuilt._interval == INTERVAL
+
+
+def test_serialize_only_carries_interval():
+    assert _tt().serialize() == {"interval": INTERVAL.total_seconds()}
+
+
+def test_summary_includes_interval():
+    assert "28 days" in _tt().summary


### PR DESCRIPTION
## Summary
- Adds `IntervalTimetable`, a custom Airflow timetable that anchors the next scheduled run on `DAG.start_date + k * interval`, recomputed on every scheduler tick.
- Replaces the need to clear DAG history when shifting the run time of a `schedule_interval=timedelta(...)` DAG — editing the DAG's `start_date` is enough to re-align the next run.
- **Wall-clock stable across DST:** the grid is computed in naive (DST-free) wall-clock space and then localized to the `start_date` timezone, so a 03:00 schedule keeps firing at 03:00 local year-round — exactly like a cron schedule. This deliberately differs from the stock `timedelta`-based `DeltaDataIntervalTimetable`, which adds an absolute duration and therefore drifts the run by an hour after each DST transition.
- Registers the timetable via `plugins/unic_plugins.py` so the webserver can deserialize it from the serialized-DAG row.
- Adds `pytest.ini` (`pythonpath = . dags plugins`, `testpaths = tests`) and a unit-test module at `tests/plugins/test_interval.py` (30 cases covering construction, alignment, catchup True/False, anchor-shift re-alignment, DST spring-forward/fall-back stability, serialize/deserialize).
- Adds `freezegun~=1.5.0` to `requirements.txt` for test-time clock control.
- Extends the CI pylint command to also cover `plugins/timetables/**.py` and `tests/plugins/**.py` (the existing `*/**.py` glob only matched two-level paths, so the timetables plugin and its tests were not being linted).
- **No DAGs are migrated in this PR** — existing `schedule_interval=timedelta(...)` DAGs continue to use `DeltaDataIntervalTimetable`. A follow-up PR will migrate the five every-4-week Python DAGs.

## Background
With `schedule_interval=timedelta(...)`, Airflow uses `DeltaDataIntervalTimetable`, which chains `next.start = last_run.end`. Once a DAG has any history, editing `start_date` does not move the schedule — the operator must clear DAG history in the UI. `IntervalTimetable` re-anchors every run on `restriction.earliest` (the DAG's `start_date`), so the next slot is always `start_date + k * interval` regardless of past runs.

### DST behaviour
Because the grid math is done on naive wall-clock values and only localized at the end, slot indices land on exact integers at grid points regardless of any DST transition in between — so **no run is skipped or duplicated** across a transition; only the wall-clock time is held constant (the UTC offset shifts to compensate). This is the same DST behaviour as the cron-driven JSON DAGs, and the opposite of the absolute-duration `timedelta` schedule it is meant to replace.

## Companion change
Requires a small change in `unic-kubernetes-environments` to point Airflow's `plugins_folder` at the git-synced clone (`AIRFLOW__CORE__PLUGINS_FOLDER=/opt/airflow/dags/repo/plugins`). PR opened separately.

## Test plan
- [x] `pytest tests/plugins/test_interval.py tests/dags/test_dags.py` — 31 pass (incl. 3 DST cases asserting 03:00 holds across spring-forward and fall-back)
- [x] `pylint --load-plugins=pylint_airflow --fail-under=10.0 plugins/timetables/**.py tests/plugins/**.py` — 10.00/10
- [x] Local docker-compose smoke test: confirm `unic_plugins` appears under Admin → Plugins with `IntervalTimetable` listed under "timetables"
- [x] Post-deploy: `kubectl -n unic-prod exec deploy/unic-prod-airflow-scheduler -- printenv AIRFLOW__CORE__PLUGINS_FOLDER` returns `/opt/airflow/dags/repo/plugins`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
