### PR TITLE
⚡️ fix(eclinibase): Temp remove scheduling and increase cluster type

### DIFF
--- a/dags/config/red/curated/eclinibase_config.json
+++ b/dags/config/red/curated/eclinibase_config.json
@@ -1,6 +1,5 @@
 {
   "concurrency": 4,
-  "schedule": "20 1 * * 2,5",
   "timeout_hours": 10,
   "steps": [
     {
@@ -16,8 +15,8 @@
         ], "cluster_type" : "xsmall"}
       ],
       "datasets": [
-        {"dataset_id": "curated_eclinibase_v_identification"              , "cluster_type": "medium", "run_type": "default", "pass_date": false, "dependencies": []},
-        {"dataset_id": "curated_eclinibase_v_identification_adresse"      , "cluster_type": "medium", "run_type": "default", "pass_date": false, "dependencies": []},
+        {"dataset_id": "curated_eclinibase_v_identification"              , "cluster_type": "large", "run_type": "default", "pass_date": false, "dependencies": []},
+        {"dataset_id": "curated_eclinibase_v_identification_adresse"      , "cluster_type": "large", "run_type": "default", "pass_date": false, "dependencies": []},
         {"dataset_id": "curated_eclinibase_v_identification_autre_dossier", "cluster_type": "large" , "run_type": "default", "pass_date": false, "dependencies": []}
 
       ],


### PR DESCRIPTION
The initial load of the tables takes >8 hours. I increased the cluster_type for the initial load only to speed up the final test run. The schedule will be reinstated and the cluster types decreased back to medium once the initial run is successfull. 