### PR TITLE
:sparkles: feat: UNIC-2031 Humanize IntervalTimetable schedule label

### DIFF
--- a/plugins/timetables/interval.py
+++ b/plugins/timetables/interval.py
@@ -82,11 +82,28 @@ class IntervalTimetable(Timetable):
         if not isinstance(interval, timedelta) or interval <= timedelta(0):
             raise AirflowTimetableInvalid(f"interval must be a positive timedelta, got {interval!r}")
         self._interval = interval
-        self.description = f"Schedule: every {interval}, anchored on the DAG's start_date."
+        self.description = f"Every {self._humanize(interval)}, anchored on the DAG's start_date."
+
+    @staticmethod
+    def _humanize(interval: timedelta) -> str:
+        """Render ``interval`` as a compact human string, e.g. ``28 days`` or ``3 days, 2 hours``.
+
+        Built from the non-zero day/hour/minute/second components so the
+        misleading ``0:00:00`` time-of-day from ``str(timedelta)`` is dropped --
+        that suffix reads like a run time but isn't (the run time is set by the
+        DAG's ``start_date``, not the interval).
+        """
+        total = int(interval.total_seconds())
+        days, rem = divmod(total, 86400)
+        hours, rem = divmod(rem, 3600)
+        minutes, seconds = divmod(rem, 60)
+        units = [(days, "day"), (hours, "hour"), (minutes, "minute"), (seconds, "second")]
+        parts = [f"{value} {name}{'s' if value != 1 else ''}" for value, name in units if value]
+        return ", ".join(parts) if parts else "0 seconds"
 
     @property
     def summary(self) -> str:
-        return f"every {self._interval}"
+        return f"every {self._humanize(self._interval)}"
 
     def __eq__(self, other: Any) -> bool:
         """

--- a/tests/plugins/test_interval.py
+++ b/tests/plugins/test_interval.py
@@ -241,3 +241,40 @@ def test_serialize_only_carries_interval():
 
 def test_summary_includes_interval():
     assert "28 days" in _tt().summary
+
+
+def test_summary_drops_zero_time_of_day():
+    # str(timedelta(weeks=4)) is "28 days, 0:00:00"; the "0:00:00" is misleading
+    # (it is not the run time) and must not leak into the UI label.
+    assert "0:00:00" not in _tt().summary
+
+
+def test_description_has_no_schedule_prefix():
+    # Airflow prepends "Schedule: " to the description in the UI tooltip, so the
+    # description itself must not start with it (else it doubles up).
+    assert not _tt().description.startswith("Schedule:")
+
+
+@pytest.mark.parametrize(
+    "interval, expected",
+    [
+        # whole-day intervals (the common case) drop the time-of-day noise
+        (timedelta(weeks=4), "28 days"),
+        (timedelta(weeks=2, days=3), "17 days"),
+        (timedelta(days=1), "1 day"),
+        # single non-day units
+        (timedelta(hours=12), "12 hours"),
+        (timedelta(minutes=30), "30 minutes"),
+        (timedelta(seconds=1), "1 second"),
+        # mixed units, with zero components skipped
+        (timedelta(days=3, hours=2), "3 days, 2 hours"),
+        (timedelta(hours=2, seconds=5), "2 hours, 5 seconds"),
+        (timedelta(minutes=90), "1 hour, 30 minutes"),
+        # every unit present, all singular
+        (timedelta(days=1, hours=1, minutes=1, seconds=1), "1 day, 1 hour, 1 minute, 1 second"),
+        # every unit present, all plural
+        (timedelta(days=10, hours=5, minutes=30, seconds=15), "10 days, 5 hours, 30 minutes, 15 seconds"),
+    ],
+)
+def test_humanize_formats_components(interval, expected):
+    assert IntervalTimetable._humanize(interval) == expected


### PR DESCRIPTION
Cleans up the `IntervalTimetable` schedule label in the UI.

- **Before:** `Schedule: every 28 days, 0:00:00` (the `0:00:00` is misleading — it's not the run time) + a doubled `Schedule: Schedule:` in the tooltip.
- **After:** `Schedule: every 28 days`, tooltip `Schedule: Every 28 days, anchored on the DAG's start_date.`

Adds a `_humanize()` helper (drops zero time components), removes the leading `Schedule:` from the description, and adds tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
